### PR TITLE
remove unsupported character

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -18,7 +18,7 @@ export const Banner = observer(() => {
                   <img src={`${helper.cdn('images/smallball.png')}`} alt="" />
                 </Box>
             </Box>
-            <Flex position="absolute" zIndex="3" w="100%" h="100%" top="0"
+            <Flex position="absolute" zIndex="3" w="100%" h="100%" top="0"
               left="0" alignItems="center"  direction="column"
               pt={{base: "4rem", sm: "8rem", md: "8rem", lg: "12rem", xl: "14rem", "2xl": "14rem"}}>
               <Text


### PR DESCRIPTION
Removed the character over the banner that cannot be rendered correctly with the current font.
![image](https://user-images.githubusercontent.com/1294467/132388632-c8a2c324-268f-44b5-b368-f7c971617308.png)

Observed with:
Chrome - 93.0.4577.63
Ms Edge Version - 93.0.961.38 (Official build) (64-bit)
Brave Version - 1.29.77 Chromium: 93.0.4577.63 (Official Build) (64-bit)

